### PR TITLE
Change content-disposition to "inline" from "attachment"

### DIFF
--- a/lib/src/Upload.ts
+++ b/lib/src/Upload.ts
@@ -422,7 +422,7 @@ export class Upload {
           if (summary.name !== null) {
             xhr.setRequestHeader(
               "content-disposition",
-              `attachment; filename="${encodeURIComponent(summary.name)}"; filename*=UTF-8''${encodeURIComponent(
+              `inline; filename="${encodeURIComponent(summary.name)}"; filename*=UTF-8''${encodeURIComponent(
                 summary.name
               )}`
             );


### PR DESCRIPTION
Resolves https://github.com/upload-js/upload-js/issues/4.

Allows uploaded images (and any other browser-viewable media) to be viewed directly in the browser, rather than the user being prompted to download the file.