### PR TITLE
Add missing types declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "require": "./dist/browser/cjs/main.js",
         "import": "./dist/browser/esm/main.mjs"
       },
+      "types": "./dist/types/index.d.ts",
       "default": "./dist/browser/cjs/main.js"
     }
   },


### PR DESCRIPTION
The types declaration was missing and I kept getting the error,
```
Could not find a declaration file for module '@bytescale/sdk'. '/Users/ray/Desktop/test-monorepo/apps/next/node_modules/@bytescale/sdk/dist/browser/cjs/main.js' implicitly has an 'any' type.
  There are types at '/Users/ray/Desktop/test-monorepo/apps/next/node_modules/@bytescale/sdk/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@bytescale/sdk' library may need to update its package.json or typings.ts(7016)
  ```

for

```import * as Bytescale from "@bytescale/sdk";```

so I added it back in.